### PR TITLE
Add HTTP replacement option

### DIFF
--- a/app/src/main/java/io/legado/app/data/AppDatabase.kt
+++ b/app/src/main/java/io/legado/app/data/AppDatabase.kt
@@ -67,7 +67,7 @@ val appDb by lazy {
 }
 
 @Database(
-    version = 75,
+    version = 76,
     exportSchema = true,
     entities = [Book::class, BookGroup::class, BookSource::class, BookChapter::class,
         ReplaceRule::class, SearchBook::class, SearchKeyword::class, Cookie::class,
@@ -108,6 +108,7 @@ val appDb by lazy {
         AutoMigration(from = 72, to = 73),
         AutoMigration(from = 73, to = 74),
         AutoMigration(from = 74, to = 75),
+        AutoMigration(from = 75, to = 76),
     ]
 )
 abstract class AppDatabase : RoomDatabase() {

--- a/app/src/main/java/io/legado/app/data/entities/ReplaceRule.kt
+++ b/app/src/main/java/io/legado/app/data/entities/ReplaceRule.kt
@@ -56,7 +56,20 @@ data class ReplaceRule(
     var timeoutMillisecond: Long = 3000L,
     //排序
     @ColumnInfo(name = "sortOrder", defaultValue = "0")
-    var order: Int = Int.MIN_VALUE
+    var order: Int = Int.MIN_VALUE,
+    //是否http替换
+    @ColumnInfo(defaultValue = "0")
+    var isHttp: Boolean = false,
+    //http请求地址
+    var httpUrl: String? = null,
+    //http请求参数
+    var httpParams: String? = null,
+    //http请求头
+    var httpHeaders: String? = null,
+    //http请求方法
+    var httpMethod: String? = null,
+    //返回值jsonPath
+    var httpJsonPath: String? = null
 ) : Parcelable {
 
     override fun equals(other: Any?): Boolean {

--- a/app/src/main/java/io/legado/app/help/ReplaceAnalyzer.kt
+++ b/app/src/main/java/io/legado/app/help/ReplaceAnalyzer.kt
@@ -38,6 +38,12 @@ object ReplaceAnalyzer {
                 rule.scope = jsonItem.readString("$.useTo")
                 rule.isEnabled = jsonItem.readBool("$.enable") == true
                 rule.order = jsonItem.readInt("$.serialNumber") ?: 0
+                rule.isHttp = jsonItem.readBool("$.isHttp") == true
+                rule.httpUrl = jsonItem.readString("$.httpUrl")
+                rule.httpParams = jsonItem.readString("$.httpParams")
+                rule.httpHeaders = jsonItem.readString("$.httpHeaders")
+                rule.httpMethod = jsonItem.readString("$.httpMethod")
+                rule.httpJsonPath = jsonItem.readString("$.httpJsonPath")
                 return@runCatching rule
             }
             return@runCatching replaceRule

--- a/app/src/main/java/io/legado/app/help/book/ContentProcessor.kt
+++ b/app/src/main/java/io/legado/app/help/book/ContentProcessor.kt
@@ -18,6 +18,7 @@ import io.legado.app.utils.toastOnUi
 import kotlinx.coroutines.CancellationException
 import splitties.init.appCtx
 import java.lang.ref.WeakReference
+import io.legado.app.help.book.HttpReplace
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.regex.Pattern
 
@@ -148,10 +149,19 @@ class ContentProcessor private constructor(
                 effectiveReplaceRules = arrayListOf()
                 mContent = mContent.lines().joinToString("\n") { it.trim() }
                 getContentReplaceRules().forEach { item ->
-                    if (item.pattern.isEmpty()) {
-                        return@forEach
-                    }
                     try {
+                        if (item.isHttp && !item.httpUrl.isNullOrBlank()) {
+                            HttpReplace.request(item, mContent)?.let { tmp ->
+                                if (mContent != tmp) {
+                                    effectiveReplaceRules.add(item)
+                                    mContent = tmp
+                                }
+                            }
+                            return@forEach
+                        }
+                        if (item.pattern.isEmpty()) {
+                            return@forEach
+                        }
                         val tmp = if (item.isRegex) {
                             mContent.replace(
                                 item.regex,

--- a/app/src/main/java/io/legado/app/help/book/HttpReplace.kt
+++ b/app/src/main/java/io/legado/app/help/book/HttpReplace.kt
@@ -1,0 +1,43 @@
+package io.legado.app.help.book
+
+import io.legado.app.data.entities.ReplaceRule
+import io.legado.app.help.http.addHeaders
+import io.legado.app.help.http.get
+import io.legado.app.help.http.newCallStrResponse
+import io.legado.app.help.http.okHttpClient
+import io.legado.app.help.http.postForm
+import io.legado.app.utils.GSON
+import io.legado.app.utils.fromJsonObject
+import io.legado.app.utils.jsonPath
+import io.legado.app.constant.AppLog
+import kotlinx.coroutines.runBlocking
+
+object HttpReplace {
+    fun request(rule: ReplaceRule, text: String): String? = runBlocking {
+        try {
+            val headers = GSON.fromJsonObject<Map<String, String>>(rule.httpHeaders).getOrNull() ?: emptyMap()
+            val params = GSON.fromJsonObject<Map<String, String>>(rule.httpParams).getOrNull()?.toMutableMap() ?: mutableMapOf()
+            params["text"] = text
+            val method = rule.httpMethod?.uppercase() ?: "POST"
+            val res = okHttpClient.newCallStrResponse {
+                addHeaders(headers)
+                if (method == "GET") {
+                    get(rule.httpUrl ?: "", params)
+                } else {
+                    url(rule.httpUrl ?: "")
+                    postForm(params.mapValues { it.value.toString() })
+                }
+            }
+            val body = res.body ?: return@runBlocking null
+            rule.httpJsonPath?.takeIf { it.isNotBlank() }?.let { path ->
+                return@runBlocking kotlin.runCatching {
+                    jsonPath.parse(body).read<String>(path)
+                }.getOrElse { body }
+            }
+            return@runBlocking body
+        } catch (e: Exception) {
+            AppLog.put("http replace error ${'$'}{e.localizedMessage}", e)
+            null
+        }
+    }
+}

--- a/app/src/main/java/io/legado/app/ui/replace/edit/ReplaceEditActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/replace/edit/ReplaceEditActivity.kt
@@ -109,6 +109,12 @@ class ReplaceEditActivity :
         etScope.setText(replaceRule.scope)
         etExcludeScope.setText(replaceRule.excludeScope)
         etTimeout.setText(replaceRule.timeoutMillisecond.toString())
+        cbUseHttp.isChecked = replaceRule.isHttp
+        etHttpUrl.setText(replaceRule.httpUrl)
+        etHttpParams.setText(replaceRule.httpParams)
+        etHttpHeaders.setText(replaceRule.httpHeaders)
+        etHttpMethod.setText(replaceRule.httpMethod)
+        etHttpJsonPath.setText(replaceRule.httpJsonPath)
     }
 
     private fun getReplaceRule(): ReplaceRule = binding.run {
@@ -123,6 +129,12 @@ class ReplaceEditActivity :
         replaceRule.scope = etScope.text.toString()
         replaceRule.excludeScope = etExcludeScope.text.toString()
         replaceRule.timeoutMillisecond = etTimeout.text.toString().ifEmpty { "3000" }.toLong()
+        replaceRule.isHttp = cbUseHttp.isChecked
+        replaceRule.httpUrl = etHttpUrl.text.toString()
+        replaceRule.httpParams = etHttpParams.text.toString()
+        replaceRule.httpHeaders = etHttpHeaders.text.toString()
+        replaceRule.httpMethod = etHttpMethod.text.toString()
+        replaceRule.httpJsonPath = etHttpJsonPath.text.toString()
         return replaceRule
     }
 

--- a/app/src/main/res/layout/activity_replace_edit.xml
+++ b/app/src/main/res/layout/activity_replace_edit.xml
@@ -165,6 +165,73 @@
                     tools:ignore="SpeakableTextPresentCheck,TouchTargetSizeCheck" />
             </io.legado.app.ui.widget.text.TextInputLayout>
 
+            <io.legado.app.lib.theme.view.ThemeCheckBox
+                android:id="@+id/cb_use_http"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/use_http_replace"
+                tools:ignore="TouchTargetSizeCheck" />
+
+            <io.legado.app.ui.widget.text.TextInputLayout
+                android:id="@+id/til_http_url"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/http_url">
+
+                <io.legado.app.lib.theme.view.ThemeEditText
+                    android:id="@+id/et_http_url"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
+            </io.legado.app.ui.widget.text.TextInputLayout>
+
+            <io.legado.app.ui.widget.text.TextInputLayout
+                android:id="@+id/til_http_params"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/http_params">
+
+                <io.legado.app.lib.theme.view.ThemeEditText
+                    android:id="@+id/et_http_params"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
+            </io.legado.app.ui.widget.text.TextInputLayout>
+
+            <io.legado.app.ui.widget.text.TextInputLayout
+                android:id="@+id/til_http_headers"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/http_headers">
+
+                <io.legado.app.lib.theme.view.ThemeEditText
+                    android:id="@+id/et_http_headers"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
+            </io.legado.app.ui.widget.text.TextInputLayout>
+
+            <io.legado.app.ui.widget.text.TextInputLayout
+                android:id="@+id/til_http_method"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/http_method">
+
+                <io.legado.app.lib.theme.view.ThemeEditText
+                    android:id="@+id/et_http_method"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
+            </io.legado.app.ui.widget.text.TextInputLayout>
+
+            <io.legado.app.ui.widget.text.TextInputLayout
+                android:id="@+id/til_http_json_path"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/http_json_path">
+
+                <io.legado.app.lib.theme.view.ThemeEditText
+                    android:id="@+id/et_http_json_path"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
+            </io.legado.app.ui.widget.text.TextInputLayout>
+
         </LinearLayout>
     </io.legado.app.ui.widget.NoChildScrollNestedScrollView>
 

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -997,6 +997,12 @@
     <string name="input_verification_code">输入验证码</string>
     <string name="verification_code">验证码</string>
     <string name="timeout_millisecond">超时毫秒数</string>
+    <string name="use_http_replace">使用HTTP替换</string>
+    <string name="http_url">请求地址</string>
+    <string name="http_params">请求参数</string>
+    <string name="http_headers">请求头</string>
+    <string name="http_method">请求方法</string>
+    <string name="http_json_path">JSONPath</string>
     <string name="file_not_supported">文件 %1$s 不受支持，是否继续打开？</string>
     <string name="import_tts">导入 TTS</string>
     <string name="import_theme">导入主题</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1000,6 +1000,12 @@
     <string name="input_verification_code">Enter the CAPTCHA</string>
     <string name="verification_code">Verification code</string>
     <string name="timeout_millisecond">Timed out milliseconds</string>
+    <string name="use_http_replace">Use HTTP replace</string>
+    <string name="http_url">Request URL</string>
+    <string name="http_params">Request parameters</string>
+    <string name="http_headers">Request headers</string>
+    <string name="http_method">HTTP method</string>
+    <string name="http_json_path">JSONPath</string>
     <string name="file_not_supported">Continue to open although %1$s is not supported ?</string>
     <string name="import_tts">Import TTS</string>
     <string name="import_theme">Import theme</string>


### PR DESCRIPTION
## Summary
- allow ReplaceRule to perform HTTP-based replacements
- support configuration of URL, params, headers, method and JSONPath
- show new options in ReplaceRule editor UI
- upgrade DB schema for new columns

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684be26077c483248fefb30849bffed2