### PR TITLE
Add manual http replace trigger

### DIFF
--- a/app/src/main/java/io/legado/app/help/book/HttpReplace.kt
+++ b/app/src/main/java/io/legado/app/help/book/HttpReplace.kt
@@ -19,6 +19,7 @@ object HttpReplace {
             val params = GSON.fromJsonObject<Map<String, String>>(rule.httpParams).getOrNull()?.toMutableMap() ?: mutableMapOf()
             params["text"] = text
             val method = rule.httpMethod?.uppercase() ?: "POST"
+            AppLog.put("http replace request ${rule.httpUrl} ${method} ${params}")
             val res = okHttpClient.newCallStrResponse {
                 addHeaders(headers)
                 if (method == "GET") {
@@ -29,6 +30,7 @@ object HttpReplace {
                 }
             }
             val body = res.body ?: return@runBlocking null
+            AppLog.put("http replace response ${body.take(100)}")
             rule.httpJsonPath?.takeIf { it.isNotBlank() }?.let { path ->
                 return@runBlocking kotlin.runCatching {
                     jsonPath.parse(body).read<String>(path)

--- a/app/src/main/java/io/legado/app/ui/book/read/ReadBookActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/ReadBookActivity.kt
@@ -1168,6 +1168,13 @@ class ReadBookActivity : BaseReadBookActivity(),
         replaceActivity.launch(Intent(this, ReplaceRuleActivity::class.java))
     }
 
+    override fun httpReplace() {
+        ReadBook.book?.let {
+            viewModel.refreshContentDur(it)
+            showDialogFragment<AppLogDialog>()
+        }
+    }
+
     /**
      * 打开目录
      */

--- a/app/src/main/java/io/legado/app/ui/book/read/ReadMenu.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/ReadMenu.kt
@@ -199,6 +199,8 @@ class ReadMenu @JvmOverloads constructor(
         fabAutoPage.setColorFilter(textColor)
         fabReplaceRule.backgroundTintList = bottomBackgroundList
         fabReplaceRule.setColorFilter(textColor)
+        fabHttpReplace.backgroundTintList = bottomBackgroundList
+        fabHttpReplace.setColorFilter(textColor)
         fabNightTheme.backgroundTintList = bottomBackgroundList
         fabNightTheme.setColorFilter(textColor)
         tvPre.setTextColor(textColor)
@@ -449,6 +451,9 @@ class ReadMenu @JvmOverloads constructor(
         //替换
         fabReplaceRule.setOnClickListener { callBack.openReplaceRule() }
 
+        //http替换
+        fabHttpReplace.setOnClickListener { callBack.httpReplace() }
+
         //夜间模式
         fabNightTheme.setOnClickListener {
             AppConfig.isNightTheme = !AppConfig.isNightTheme
@@ -582,6 +587,7 @@ class ReadMenu @JvmOverloads constructor(
         fun showLogin()
         fun payAction()
         fun disableSource()
+        fun httpReplace()
         fun skipToChapter(index: Int)
         fun onMenuShow()
         fun onMenuHide()

--- a/app/src/main/res/layout/view_read_menu.xml
+++ b/app/src/main/res/layout/view_read_menu.xml
@@ -195,6 +195,26 @@
                 android:layout_weight="1" />
 
             <com.google.android.material.floatingactionbutton.FloatingActionButton
+                android:id="@+id/fabHttpReplace"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="16dp"
+                android:contentDescription="@string/http_replace"
+                android:src="@drawable/ic_refresh_black_24dp"
+                android:tint="@color/primaryText"
+                android:tooltipText="@string/http_replace"
+                app:backgroundTint="@color/background_menu"
+                app:elevation="2dp"
+                app:fabSize="mini"
+                app:pressedTranslationZ="2dp"
+                tools:ignore="UnusedAttribute" />
+
+            <Space
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1" />
+
+            <com.google.android.material.floatingactionbutton.FloatingActionButton
                 android:id="@+id/fabNightTheme"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -197,6 +197,7 @@
     <string name="replace_rule_edit">Editar regla de reemplazo</string>
     <string name="replace_rule">Modelo</string>
     <string name="replace_to">Reemplazo</string>
+    <string name="http_replace">Reemplazo HTTP</string>
     <string name="img_cover">Portada</string>
     <string name="book">Libro</string>
     <string name="volume_key_page">Botones de volumen para pasar página</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -201,6 +201,7 @@
     <string name="replace_rule_edit">Edit replacement rule</string>
     <string name="replace_rule">Pattern</string>
     <string name="replace_to">Replacement</string>
+    <string name="http_replace">HTTP置換</string>
     <string name="img_cover">Cover</string>
     <string name="book">Book</string>
     <string name="volume_key_page">Volume keys to turn page</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -201,6 +201,7 @@
     <string name="replace_rule_edit">Editar regra de substituição</string>
     <string name="replace_rule">Modelo</string>
     <string name="replace_to">Substituição</string>
+    <string name="http_replace">Substituição HTTP</string>
     <string name="img_cover">Capa</string>
     <string name="book">Livro</string>
     <string name="volume_key_page">Botões de volume para virar páginas</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -196,6 +196,7 @@
     <string name="replace_rule_edit">Sửa quy tắc thay thế</string>
     <string name="replace_rule">Hoa văn</string>
     <string name="replace_to">Thay thế</string>
+    <string name="http_replace">Thay thế HTTP</string>
     <string name="img_cover">Bìa</string>
     <string name="book">Sách</string>
     <string name="volume_key_page">Phím âm lượng để lật trang</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -193,6 +193,7 @@
     <string name="replace_rule_edit">替換規則編輯</string>
     <string name="replace_rule">替換規則</string>
     <string name="replace_to">替換為</string>
+    <string name="http_replace">執行網絡替換</string>
     <string name="img_cover">封面</string>
     <string name="book">書</string>
     <string name="volume_key_page">音量鍵翻頁</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -195,6 +195,7 @@
     <string name="replace_rule_edit">取代規則編輯</string>
     <string name="replace_rule">取代規則</string>
     <string name="replace_to">取代為</string>
+    <string name="http_replace">執行網路替換</string>
     <string name="img_cover">封面</string>
     <string name="book">書</string>
     <string name="volume_key_page">音量鍵翻頁</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -200,6 +200,7 @@
     <string name="replace_rule_edit">替换规则编辑</string>
     <string name="replace_rule">替换规则</string>
     <string name="replace_to">替换为</string>
+    <string name="http_replace">执行网络替换</string>
     <string name="img_cover">封面</string>
    <string name="book">书</string>
     <string name="volume_key_page">音量键翻页</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -201,6 +201,7 @@
     <string name="replace_rule_edit">Edit replacement rule</string>
     <string name="replace_rule">Pattern</string>
     <string name="replace_to">Replacement</string>
+    <string name="http_replace">HTTP replace</string>
     <string name="img_cover">Cover</string>
     <string name="book">Book</string>
     <string name="volume_key_page">Volume keys to turn page</string>


### PR DESCRIPTION
## Summary
- add `fabHttpReplace` button in reading menu
- handle button events to trigger HTTP replacement
- log request/response for HTTP replacement
- expose new callback for manual HTTP replace
- add translations for new string

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684bfe57d55883248c47ac5ce1cab814