### PR TITLE
Add id to HTTP replace logs

### DIFF
--- a/app/src/main/java/io/legado/app/help/book/HttpReplace.kt
+++ b/app/src/main/java/io/legado/app/help/book/HttpReplace.kt
@@ -14,17 +14,18 @@ import kotlinx.coroutines.runBlocking
 
 object HttpReplace {
     fun request(rule: ReplaceRule, text: String): String? = runBlocking {
+        val id = System.currentTimeMillis().toString()
         try {
             val headers = GSON.fromJsonObject<Map<String, String>>(rule.httpHeaders).getOrNull() ?: emptyMap()
             val params = GSON.fromJsonObject<Map<String, String>>(rule.httpParams).getOrNull()?.toMutableMap() ?: mutableMapOf()
             params["text"] = text
             val method = rule.httpMethod?.uppercase() ?: "POST"
-            AppLog.put("http replace request ${rule.httpUrl} ${method}")
+            AppLog.put("[$id] http replace request url=${rule.httpUrl} method=$method rule=${rule.name}")
             if (headers.isNotEmpty()) {
-                AppLog.put("headers: ${'$'}headers")
+                AppLog.put("[$id] headers: ${'$'}headers")
             }
             if (params.isNotEmpty()) {
-                AppLog.put("params: ${'$'}params")
+                AppLog.put("[$id] params: ${'$'}params")
             }
             val res = okHttpClient.newCallStrResponse {
                 addHeaders(headers)
@@ -37,18 +38,18 @@ object HttpReplace {
             }
             val body = res.body ?: return@runBlocking null
 
-            AppLog.put("http replace response ${'$'}body")
+            AppLog.put("[$id] http replace response ${'$'}body")
 
             rule.httpJsonPath?.takeIf { it.isNotBlank() }?.let { path ->
                 val result = kotlin.runCatching {
                     jsonPath.parse(body).read<String>(path)
                 }.getOrElse { body }
-                AppLog.put("http replace result ${'$'}result")
+                AppLog.put("[$id] http replace result ${'$'}result")
                 return@runBlocking result
             }
             return@runBlocking body
         } catch (e: Exception) {
-            AppLog.put("http replace error ${'$'}{e.localizedMessage}", e)
+            AppLog.put("[$id] http replace error ${'$'}{e.localizedMessage}", e)
             null
         }
     }


### PR DESCRIPTION
## Summary
- mark each HTTP replace request with a unique id
- log request URL/method, headers, params, response, and JSONPath result with the id

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684f7d2972d88324bdf63d4da0465ffa