### PR TITLE
Improve HTTP rule editing

### DIFF
--- a/app/src/main/java/io/legado/app/ui/replace/edit/ReplaceEditActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/replace/edit/ReplaceEditActivity.kt
@@ -17,6 +17,7 @@ import io.legado.app.lib.dialogs.SelectItem
 import io.legado.app.ui.widget.keyboard.KeyboardToolPop
 import io.legado.app.utils.GSON
 import io.legado.app.utils.imeHeight
+import io.legado.app.utils.toJsonMapLines
 import io.legado.app.utils.sendToClip
 import io.legado.app.utils.setOnApplyWindowInsetsListenerCompat
 import io.legado.app.utils.showHelp
@@ -131,8 +132,8 @@ class ReplaceEditActivity :
         replaceRule.timeoutMillisecond = etTimeout.text.toString().ifEmpty { "3000" }.toLong()
         replaceRule.isHttp = cbUseHttp.isChecked
         replaceRule.httpUrl = etHttpUrl.text.toString()
-        replaceRule.httpParams = etHttpParams.text.toString()
-        replaceRule.httpHeaders = etHttpHeaders.text.toString()
+        replaceRule.httpParams = etHttpParams.text.toString().toJsonMapLines()
+        replaceRule.httpHeaders = etHttpHeaders.text.toString().toJsonMapLines()
         replaceRule.httpMethod = etHttpMethod.text.toString()
         replaceRule.httpJsonPath = etHttpJsonPath.text.toString()
         return replaceRule

--- a/app/src/main/java/io/legado/app/utils/LogUtils.kt
+++ b/app/src/main/java/io/legado/app/utils/LogUtils.kt
@@ -69,6 +69,7 @@ object LogUtils {
             val date = getCurrentDateStr(TIME_PATTERN).replace(" ", "_").replace(":", "-")
             val logPath = FileUtils.getPath(root = logFolder, "appLog-$date.txt")
             return AsyncFileHandler(logPath).apply {
+                encoding = "UTF-8"
                 formatter = object : java.util.logging.Formatter() {
                     override fun format(record: LogRecord): String {
                         // 设置文件输出格式

--- a/app/src/main/java/io/legado/app/utils/StringExtensions.kt
+++ b/app/src/main/java/io/legado/app/utils/StringExtensions.kt
@@ -10,6 +10,7 @@ import android.text.Editable
 import cn.hutool.core.net.URLEncodeUtil
 import io.legado.app.constant.AppPattern
 import io.legado.app.constant.AppPattern.dataUriRegex
+import io.legado.app.utils.GSON
 import java.io.File
 import java.lang.Character.codePointCount
 import java.lang.Character.offsetByCodePoints
@@ -140,3 +141,25 @@ fun String.escapeRegex(): String {
 }
 
 fun String.encodeURI(): String = URLEncodeUtil.encodeQuery(this)
+
+/**
+ * Convert lines of `key:value` or `key=value` pairs into JSON map string.
+ * If the text is already a JSON object or empty, return original text.
+ */
+fun String.toJsonMapLines(): String {
+    val str = trim()
+    if (str.isEmpty() || str.isJsonObject()) return str
+    val map = linkedMapOf<String, String>()
+    str.lineSequence().forEach { line ->
+        val content = line.trim()
+        if (content.isNotEmpty()) {
+            val delimiterIndex = content.indexOfFirst { it == ':' || it == '=' }
+            if (delimiterIndex > 0) {
+                val key = content.substring(0, delimiterIndex).trim()
+                val value = content.substring(delimiterIndex + 1).trim()
+                if (key.isNotEmpty()) map[key] = value
+            }
+        }
+    }
+    return if (map.isEmpty()) str else GSON.toJson(map)
+}


### PR DESCRIPTION
## Summary
- parse headers and params from simple `key:value` lines for ReplaceRule
- fix log file encoding to UTF-8 to avoid garbled text

## Testing
- `./gradlew tasks --all` *(fails: Unable to download gradle)*

------
https://chatgpt.com/codex/tasks/task_e_684fb564ad0c8324a512904153e04c65