### PR TITLE
Add HTTP-based content replacement

### DIFF
--- a/app/src/main/java/io/legado/app/constant/PreferKey.kt
+++ b/app/src/main/java/io/legado/app/constant/PreferKey.kt
@@ -181,4 +181,6 @@ object PreferKey {
     const val readBarStyleFollowPage = "readBarStyleFollowPage"
     const val contentSelectSpeakMod = "contentReadAloudMod"
 
+    const val httpReplaceConfig = "httpReplaceConfig"
+
 }

--- a/app/src/main/java/io/legado/app/ui/book/read/HttpReplaceDialog.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/HttpReplaceDialog.kt
@@ -1,0 +1,165 @@
+package io.legado.app.ui.book.read
+
+import android.os.Bundle
+import android.view.View
+import android.view.ViewGroup
+import androidx.appcompat.widget.Toolbar
+import androidx.lifecycle.lifecycleScope
+import io.legado.app.R
+import io.legado.app.base.BaseDialogFragment
+import io.legado.app.databinding.DialogHttpReplaceBinding
+import io.legado.app.databinding.ItemHeaderPairBinding
+import io.legado.app.help.http.addHeaders
+import io.legado.app.help.http.get
+import io.legado.app.help.http.newCallStrResponse
+import io.legado.app.help.http.okHttpClient
+import io.legado.app.help.http.postForm
+import io.legado.app.lib.theme.primaryColor
+import io.legado.app.model.ReadBook
+import io.legado.app.constant.PreferKey
+import io.legado.app.utils.*
+import io.legado.app.utils.GSON
+import io.legado.app.utils.viewbindingdelegate.viewBinding
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import com.jayway.jsonpath.JsonPath
+
+data class HttpReplaceConfig(
+    var url: String = "",
+    var method: String = "GET",
+    var paramKey: String = "content",
+    var headers: LinkedHashMap<String, String> = LinkedHashMap(),
+    var jsonPath: String = ""
+)
+
+class HttpReplaceDialog : BaseDialogFragment(R.layout.dialog_http_replace, true) {
+
+    private val binding by viewBinding(DialogHttpReplaceBinding::bind)
+    private val toolbarListener = Toolbar.OnMenuItemClickListener { item ->
+        when (item.itemId) {
+            R.id.menu_save -> {
+                saveConfig()
+                requireContext().toastOnUi(R.string.success)
+            }
+        }
+        true
+    }
+
+    override fun onStart() {
+        super.onStart()
+        setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
+    }
+
+    override fun onFragmentCreated(view: View, savedInstanceState: Bundle?) {
+        binding.toolBar.setBackgroundColor(primaryColor)
+        binding.toolBar.inflateMenu(R.menu.save)
+        binding.toolBar.menu.applyTint(requireContext())
+        binding.toolBar.setOnMenuItemClickListener(toolbarListener)
+        binding.spMethod.setAdapter(android.widget.ArrayAdapter(
+            requireContext(),
+            android.R.layout.simple_dropdown_item_1line,
+            arrayOf("GET", "POST")
+        ))
+        binding.tvAddHeader.setOnClickListener { addHeaderView() }
+        loadConfig()
+        binding.tvSend.setOnClickListener { sendRequest() }
+    }
+
+    private fun loadConfig() {
+        val json = requireContext().getPrefString(PreferKey.httpReplaceConfig)
+        val cfg = GSON.fromJsonObject<HttpReplaceConfig>(json).getOrNull()
+        if (cfg == null) {
+            addHeaderView()
+            return
+        }
+        binding.etUrl.setText(cfg.url)
+        binding.etParamKey.setText(cfg.paramKey)
+        binding.spMethod.setText(cfg.method, false)
+        if (cfg.headers.isEmpty()) {
+            addHeaderView()
+        } else {
+            cfg.headers.forEach { (k, v) -> addHeaderView(k, v) }
+        }
+        binding.etJsonPath.setText(cfg.jsonPath)
+    }
+
+    private fun saveConfig() {
+        val cfg = HttpReplaceConfig(
+            url = binding.etUrl.text.toString(),
+            method = if (binding.spMethod.text.toString() == "POST") "POST" else "GET",
+            paramKey = binding.etParamKey.text.toString().ifBlank { "content" },
+            headers = LinkedHashMap(collectHeaders()),
+            jsonPath = binding.etJsonPath.text.toString(),
+        )
+        requireContext().putPrefString(PreferKey.httpReplaceConfig, GSON.toJson(cfg))
+    }
+
+    private fun addHeaderView(key: String? = null, value: String? = null) {
+        val item = ItemHeaderPairBinding.inflate(layoutInflater, binding.llHeaders, false)
+        item.etKey.setText(key)
+        item.etValue.setText(value)
+        item.ivDelete.setOnClickListener { binding.llHeaders.removeView(item.root) }
+        binding.llHeaders.addView(item.root)
+    }
+
+    private fun collectHeaders(): Map<String, String> {
+        val map = LinkedHashMap<String, String>()
+        for (i in 0 until binding.llHeaders.childCount) {
+            val child = binding.llHeaders.getChildAt(i)
+            val item = ItemHeaderPairBinding.bind(child)
+            val k = item.etKey.text.toString()
+            if (k.isNotBlank()) {
+                map[k] = item.etValue.text.toString()
+            }
+        }
+        return map
+    }
+
+    private fun sendRequest() {
+        val url = binding.etUrl.text.toString()
+        if (url.isBlank()) return
+        val paramKey = binding.etParamKey.text.toString().ifBlank { "content" }
+        val headers = collectHeaders()
+        val method = if (binding.spMethod.text.toString() == "POST") "POST" else "GET"
+        val jsonPath = binding.etJsonPath.text.toString()
+        val content = ReadBook.curTextChapter?.getContent() ?: return
+        binding.tvResult.setText("")
+        lifecycleScope.launch(Dispatchers.IO) {
+            runCatching {
+                if (method == "GET") {
+                    okHttpClient.newCallStrResponse {
+                        get(url, mapOf(paramKey to content))
+                        addHeaders(headers)
+                    }
+                } else {
+                    okHttpClient.newCallStrResponse {
+                        url(url)
+                        addHeaders(headers)
+                        postForm(mapOf(paramKey to content))
+                    }
+                }
+            }.onSuccess { res ->
+                val body = res.body ?: ""
+                val sb = StringBuilder()
+                sb.appendLine("url: $url")
+                sb.appendLine("method: $method")
+                sb.appendLine("headers: $headers")
+                sb.appendLine("code: ${res.raw.code}")
+                sb.appendLine("data: $body")
+                if (jsonPath.isNotBlank()) {
+                    kotlin.runCatching {
+                        val value = JsonPath.parse(body).read<Any?>(jsonPath)
+                        sb.appendLine("jsonPath: $value")
+                    }
+                }
+                launch(Dispatchers.Main) {
+                    binding.tvResult.setText(sb.toString())
+                }
+            }.onFailure {
+                launch(Dispatchers.Main) {
+                    binding.tvResult.setText(it.localizedMessage)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/io/legado/app/ui/book/read/ReadBookActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/ReadBookActivity.kt
@@ -72,6 +72,7 @@ import io.legado.app.ui.book.bookmark.BookmarkDialog
 import io.legado.app.ui.book.changesource.ChangeBookSourceDialog
 import io.legado.app.ui.book.changesource.ChangeChapterSourceDialog
 import io.legado.app.ui.book.info.BookInfoActivity
+import io.legado.app.ui.book.read.HttpReplaceDialog
 import io.legado.app.ui.book.read.config.AutoReadDialog
 import io.legado.app.ui.book.read.config.BgTextConfigDialog.Companion.BG_COLOR
 import io.legado.app.ui.book.read.config.BgTextConfigDialog.Companion.TEXT_COLOR
@@ -618,6 +619,8 @@ class ReadBookActivity : BaseReadBookActivity(),
             }
 
             R.id.menu_effective_replaces -> showDialogFragment<EffectiveReplacesDialog>()
+
+            R.id.menu_http_replace -> showDialogFragment(HttpReplaceDialog())
 
             R.id.menu_help -> showHelp()
         }

--- a/app/src/main/res/layout/dialog_http_replace.xml
+++ b/app/src/main/res/layout/dialog_http_replace.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp">
+
+    <LinearLayout
+        android:id="@+id/vw_bg"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/shape_card_view"
+        android:orientation="vertical">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/tool_bar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:theme="?attr/actionBarStyle"
+            app:title="@string/http_replace"
+            app:popupTheme="@style/AppTheme.PopupOverlay"
+            app:titleTextAppearance="@style/ToolbarTitle" />
+
+        <androidx.core.widget.NestedScrollView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:overScrollMode="ifContentScrolls">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <io.legado.app.ui.widget.text.TextInputLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/request_url">
+
+                    <io.legado.app.lib.theme.view.ThemeEditText
+                        android:id="@+id/et_url"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        tools:ignore="TouchTargetSizeCheck,SpeakableTextPresentCheck" />
+
+                </io.legado.app.ui.widget.text.TextInputLayout>
+
+                <io.legado.app.ui.widget.text.TextInputLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/request_param_key">
+
+                    <io.legado.app.lib.theme.view.ThemeEditText
+                        android:id="@+id/et_param_key"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="content"
+                        tools:ignore="TouchTargetSizeCheck,SpeakableTextPresentCheck" />
+
+                </io.legado.app.ui.widget.text.TextInputLayout>
+
+                <io.legado.app.ui.widget.text.TextInputLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/request_method">
+
+                    <io.legado.app.ui.widget.text.AutoCompleteTextView
+                        android:id="@+id/sp_method"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        tools:ignore="TouchTargetSizeCheck,SpeakableTextPresentCheck" />
+
+                </io.legado.app.ui.widget.text.TextInputLayout>
+
+                <TextView
+                    android:id="@+id/tv_add_header"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:drawableLeft="@drawable/ic_add"
+                    android:text="@string/add_header"
+                    android:padding="8dp"
+                    tools:ignore="RtlSymmetry" />
+
+                <LinearLayout
+                    android:id="@+id/ll_headers"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical" />
+
+                <io.legado.app.ui.widget.text.TextInputLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/jsonpath">
+
+                    <io.legado.app.lib.theme.view.ThemeEditText
+                        android:id="@+id/et_json_path"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        tools:ignore="TouchTargetSizeCheck,SpeakableTextPresentCheck" />
+
+                </io.legado.app.ui.widget.text.TextInputLayout>
+
+                <io.legado.app.ui.widget.text.AccentTextView
+                    android:id="@+id/tv_send"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:padding="8dp"
+                    android:text="@string/send_request" />
+
+                <io.legado.app.lib.theme.view.ThemeEditText
+                    android:id="@+id/tv_result"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="result"
+                    android:inputType="textMultiLine"
+                    tools:ignore="TouchTargetSizeCheck,SpeakableTextPresentCheck" />
+
+            </LinearLayout>
+        </androidx.core.widget.NestedScrollView>
+
+    </LinearLayout>
+</FrameLayout>

--- a/app/src/main/res/layout/item_header_pair.xml
+++ b/app/src/main/res/layout/item_header_pair.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal">
+
+    <io.legado.app.lib.theme.view.ThemeEditText
+        android:id="@+id/et_key"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:hint="@string/key"
+        tools:ignore="TouchTargetSizeCheck,SpeakableTextPresentCheck" />
+
+    <io.legado.app.lib.theme.view.ThemeEditText
+        android:id="@+id/et_value"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:hint="@string/value"
+        tools:ignore="TouchTargetSizeCheck,SpeakableTextPresentCheck" />
+
+    <ImageView
+        android:id="@+id/iv_delete"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:padding="2dp"
+        android:src="@drawable/ic_outline_delete"
+        android:contentDescription="@string/delete" />
+</LinearLayout>

--- a/app/src/main/res/menu/book_read.xml
+++ b/app/src/main/res/menu/book_read.xml
@@ -143,6 +143,11 @@
         app:showAsAction="never" />
 
     <item
+        android:id="@+id/menu_http_replace"
+        android:title="@string/http_replace"
+        app:showAsAction="never" />
+
+    <item
         android:id="@+id/menu_log"
         android:title="@string/log"
         app:showAsAction="never" />

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -964,6 +964,15 @@
     <string name="menu_refresh_after">刷新之后章节</string>
     <string name="menu_refresh_all">刷新全部章节</string>
     <string name="edit_content">编辑内容</string>
+    <string name="http_replace">HTTP替换</string>
+    <string name="request_url">请求地址</string>
+    <string name="request_method">请求方式</string>
+    <string name="request_param_key">内容参数名</string>
+    <string name="add_header">新增Header</string>
+    <string name="send_request">发送请求</string>
+    <string name="jsonpath">JsonPath</string>
+    <string name="key">键</string>
+    <string name="value">值</string>
     <string name="chapter_change_source">单章换源</string>
     <string name="book_change_source">整书换源</string>
     <string name="sort_by_time">时间排序</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -967,6 +967,15 @@
     <string name="menu_refresh_after">Refresh the chapter after</string>
     <string name="menu_refresh_all">Refresh all chapters</string>
     <string name="edit_content">Edit Content</string>
+    <string name="http_replace">HTTP Replace</string>
+    <string name="request_url">Request URL</string>
+    <string name="request_method">Request Method</string>
+    <string name="request_param_key">Content Param Name</string>
+    <string name="add_header">Add Header</string>
+    <string name="send_request">Send Request</string>
+    <string name="jsonpath">JsonPath</string>
+    <string name="key">Key</string>
+    <string name="value">Value</string>
     <string name="chapter_change_source">Single chapter source switching</string>
     <string name="book_change_source">Change the source of the whole book</string>
     <string name="sort_by_time">Sort by time</string>


### PR DESCRIPTION
## Summary
- add saveable settings for manual HTTP replacement
- persist URL, method, headers and JSONPath in shared prefs
- load saved config when opening dialog

## Testing
- `./gradlew -q help`

------
https://chatgpt.com/codex/tasks/task_e_684fd3a51fe483248352a91acba3c084